### PR TITLE
Cache runtime created policies

### DIFF
--- a/src/Volvoreta/Authorization/AuthorizationPolicyProvider.cs
+++ b/src/Volvoreta/Authorization/AuthorizationPolicyProvider.cs
@@ -6,8 +6,11 @@ namespace Volvoreta.Authorization
 {
     public class AuthorizationPolicyProvider : DefaultAuthorizationPolicyProvider
     {
+        private readonly AuthorizationOptions _options;
+
         public AuthorizationPolicyProvider(IOptions<AuthorizationOptions> options) : base(options)
         {
+            _options = options.Value;
         }
 
         public override async Task<AuthorizationPolicy> GetPolicyAsync(string policyName)
@@ -19,6 +22,10 @@ namespace Volvoreta.Authorization
                 policy = new AuthorizationPolicyBuilder()
                     .AddRequirements(new PermissionRequirement(policyName))
                     .Build();
+
+                // By default, policies are stored in the AuthorizationOptions instance (singleton),
+                // so we can cache all the policies created at runtime there to create the policies only once
+                _options.AddPolicy(policyName, policy);
             }
 
             return policy;


### PR DESCRIPTION
We can cache all the runtime created policies to create them only once