### PR TITLE
Consistently use the RoleClaimType defined in VolvoretaOptions

### DIFF
--- a/src/Volvoreta.Configuration.Store/ConfigurationRuntimeAuthorizationServerStore.cs
+++ b/src/Volvoreta.Configuration.Store/ConfigurationRuntimeAuthorizationServerStore.cs
@@ -21,7 +21,7 @@ namespace Volvoreta.Configuration.Store
 
         public Task<AuthotizationResult> FindAuthorizationAsync(ClaimsPrincipal user)
         {
-            var claimsRole = user.FindAll(_options.DefaultRoleClaimType).Select(x => x.Value);
+            var claimsRole = user.GetClaimRoleValues(_options.DefaultRoleClaimType);
             var application = _volvoreta.Applications.GetByName(_options.DefaultApplicationName);
             var delegation = application.Delegations.GetCurrentDelegation(user.GetSubjectId());
             var subject = GetSubject(user, delegation);
@@ -36,7 +36,7 @@ namespace Volvoreta.Configuration.Store
 
         public Task<bool> HasPermissionAsync(ClaimsPrincipal user, string permission)
         {
-            var claimsRole = user.FindAll(_options.DefaultRoleClaimType).Select(x => x.Value);
+            var claimsRole = user.GetClaimRoleValues(_options.DefaultRoleClaimType);
             var application = _volvoreta.Applications.GetByName(_options.DefaultApplicationName);
             var delegation = application.Delegations.GetCurrentDelegation(user.GetSubjectId());
             var subject = GetSubject(user, delegation);

--- a/src/Volvoreta.EntityFrameworkCore.Store/EntityFrameworkCoreRuntimeAuthorizationServerStore.cs
+++ b/src/Volvoreta.EntityFrameworkCore.Store/EntityFrameworkCoreRuntimeAuthorizationServerStore.cs
@@ -23,7 +23,7 @@ namespace Volvoreta.EntityFrameworkCore.Store
 
         public async Task<AuthotizationResult> FindAuthorizationAsync(ClaimsPrincipal user)
         {
-            var claimRoles = user.GetClaimRoleValues();
+            var claimRoles = user.GetClaimRoleValues(_options.DefaultRoleClaimType);
             var delegation = await _context.Delegations.GetCurrentDelegation(user.GetSubjectId());
             var subject = GetSubject(user, delegation);
             var roles = await _context.Roles
@@ -47,7 +47,7 @@ namespace Volvoreta.EntityFrameworkCore.Store
 
         public async Task<bool> HasPermissionAsync(ClaimsPrincipal user, string permission)
         {
-            var claimRoles = user.GetClaimRoleValues();
+            var claimRoles = user.GetClaimRoleValues(_options.DefaultRoleClaimType);
             var delegation = await _context.Delegations.GetCurrentDelegation(user.GetSubjectId());
             var subject = GetSubject(user, delegation);
 
@@ -68,7 +68,7 @@ namespace Volvoreta.EntityFrameworkCore.Store
 
         public async Task<bool> IsInRoleAsync(ClaimsPrincipal user, string role)
         {
-            var claimRoles = user.GetClaimRoleValues();
+            var claimRoles = user.GetClaimRoleValues(_options.DefaultRoleClaimType);
             var delegation = await _context.Delegations.GetCurrentDelegation(user.GetSubjectId());
             var subject = GetSubject(user, delegation);
 

--- a/src/Volvoreta/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Volvoreta/Extensions/ClaimsPrincipalExtensions.cs
@@ -19,9 +19,9 @@ namespace System.Security.Claims
             return claim.Value;
         }
 
-        public static IEnumerable<string> GetClaimRoleValues(this ClaimsPrincipal principal)
+        public static IEnumerable<string> GetClaimRoleValues(this ClaimsPrincipal principal, string roleClaimType)
         {
-            return principal.FindAll(ClaimTypes.Role)
+            return principal.FindAll(roleClaimType)
                 .Select(x => x.Value);
         }
     }


### PR DESCRIPTION
Consistently use the defined RoleClaimType in both Configuration and EntityFramework runtime stores