### PR TITLE
Allow separate RoleClaimTypes in the source and volvoreta identities

### DIFF
--- a/src/Volvoreta/DependencyInjection/VolvoretaOptions.cs
+++ b/src/Volvoreta/DependencyInjection/VolvoretaOptions.cs
@@ -1,21 +1,56 @@
-﻿using System.Security.Claims;
+﻿using System;
+using System.Security.Claims;
 
 namespace Volvoreta
 {
     public class VolvoretaOptions
     {
-        public string DefaultRoleClaimType { get; internal set; } = ClaimTypes.Role;
-        public string DefaultApplicationName { get; internal set; } = VolvoretaConstants.DefaultApplicationName;
+        public string SourceRoleClaimType { get; internal set; } = ClaimTypes.Role;
+        public string VolvoretaNameClaimType { get; internal set; } = ClaimTypes.Name;
+        public string VolvoretaRoleClaimType { get; internal set; } = ClaimTypes.Role;
+        public string ApplicationName { get; internal set; } = VolvoretaConstants.DefaultApplicationName;
 
-        public VolvoretaOptions SetDefaultRoleClaimType(string value)
+        public VolvoretaOptions SetSourceRoleClaimType(string value)
         {
-            DefaultRoleClaimType = value;
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("The value can not be null or empty", nameof(value));
+            }
+
+            SourceRoleClaimType = value;
             return this;
         }
 
-        public VolvoretaOptions SetDefaultApplicationName(string value)
+        public VolvoretaOptions SetVolvoretaNameClaimType(string value)
         {
-            DefaultApplicationName = value;
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("The value can not be null or empty", nameof(value));
+            }
+
+            VolvoretaNameClaimType = value;
+            return this;
+        }
+
+        public VolvoretaOptions SetVolvoretaRoleClaimType(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("The value can not be null or empty", nameof(value));
+            }
+
+            VolvoretaRoleClaimType = value;
+            return this;
+        }
+
+        public VolvoretaOptions SetApplicationName(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("The value can not be null or empty", nameof(value));
+            }
+
+            ApplicationName = value;
             return this;
         }
     }

--- a/src/Volvoreta/Endpoints/VolvoretaMiddleware.cs
+++ b/src/Volvoreta/Endpoints/VolvoretaMiddleware.cs
@@ -24,13 +24,16 @@ namespace Volvoreta.Endpoints
 
                 var roleClaims = authorization.Roles
                     .Where(role => role.Enabled)
-                    .Select(role => new Claim(options.DefaultRoleClaimType, role.Name));
+                    .Select(role => new Claim(options.VolvoretaRoleClaimType, role.Name));
 
                 var permissionClaims = authorization.Roles
                     .SelectMany(role => role.GetPermissions())
                     .Select(permission => new Claim(VolvoretaClaims.Permission, permission));
 
-                var identity = new ClaimsIdentity(nameof(VolvoretaMiddleware));
+                var identity = new ClaimsIdentity(
+                    authenticationType: nameof(VolvoretaMiddleware),
+                    nameType: options.VolvoretaNameClaimType,
+                    roleType: options.VolvoretaRoleClaimType);
 
                 identity.AddClaims(roleClaims);
                 identity.AddClaims(permissionClaims);

--- a/src/Volvoreta/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Volvoreta/Extensions/ClaimsPrincipalExtensions.cs
@@ -19,9 +19,11 @@ namespace System.Security.Claims
             return claim.Value;
         }
 
-        public static IEnumerable<string> GetClaimRoleValues(this ClaimsPrincipal principal)
+        public static IEnumerable<string> GetRoleClaimValues(
+            this ClaimsPrincipal principal,
+            string roleClaimType)
         {
-            return principal.FindAll(ClaimTypes.Role)
+            return principal.FindAll(roleClaimType)
                 .Select(x => x.Value);
         }
     }

--- a/test/FunctionalTests/Seedwork/TestConfigurationStartup.cs
+++ b/test/FunctionalTests/Seedwork/TestConfigurationStartup.cs
@@ -18,7 +18,12 @@ namespace FunctionalTests.Seedwork
         public void ConfigureServices(IServiceCollection services)
         {
             services
-                .AddVolvoreta()
+                .AddVolvoreta(options =>
+                {
+                    options
+                        .SetSourceRoleClaimType("sourceRole")
+                        .SetVolvoretaRoleClaimType("volvoretaRole");
+                })
                 .AddConfigurationStore(configuration)
                 .Services
                 .AddAuthentication(setup =>
@@ -26,7 +31,10 @@ namespace FunctionalTests.Seedwork
                     setup.DefaultAuthenticateScheme = TestServerDefaults.AuthenticationScheme;
                     setup.DefaultChallengeScheme = TestServerDefaults.AuthenticationScheme;
                 })
-                .AddTestServer()
+                .AddTestServer(options =>
+                {
+                    options.RoleClaimType = "sourceRole";
+                })
                 .Services
                 .AddMvc();
         }

--- a/test/FunctionalTests/Seedwork/TestEntityFrameworkCoreStartup.cs
+++ b/test/FunctionalTests/Seedwork/TestEntityFrameworkCoreStartup.cs
@@ -21,7 +21,12 @@ namespace FunctionalTests.Seedwork
         public void ConfigureServices(IServiceCollection services)
         {
             services
-                .AddVolvoreta()
+                .AddVolvoreta(options =>
+                {
+                    options
+                        .SetSourceRoleClaimType("sourceRole")
+                        .SetVolvoretaRoleClaimType("volvoretaRole");
+                })
                 .AddEntityFrameworkCoreStore(options =>
                 {
                     options.ConfigureDbContext = builder =>
@@ -43,7 +48,10 @@ namespace FunctionalTests.Seedwork
                     setup.DefaultAuthenticateScheme = TestServerDefaults.AuthenticationScheme;
                     setup.DefaultChallengeScheme = TestServerDefaults.AuthenticationScheme;
                 })
-                .AddTestServer()
+                .AddTestServer(options =>
+                {
+                    options.RoleClaimType = "sourceRole";
+                })
                 .Services
                 .AddMvc();
         }


### PR DESCRIPTION
If we are using two separate identities (good idea!) we should allow to define the RoleClaimType in both identities, the original one and the volvoreta one.

This way we can slightly simplify the query for HasPermissions because we can do this query over the VolvoretaRoles, that include the roles for the source identity that match role, subject and mappings.  