### PR TITLE
Default Policy Provider Thread Safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       sql-server:
-        image: microsoft/mssql-server-linux
+        image: mcr.microsoft.com/mssql/server
         env:
           ACCEPT_EULA: Y
           MSSQL_SA_PASSWORD: Password12!

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       sql-server:
-        image: microsoft/mssql-server-linux
+        image: mcr.microsoft.com/mssql/server
         env:
           ACCEPT_EULA: Y
           MSSQL_SA_PASSWORD: Password12!

--- a/.github/workflows/nuget-preview.yml
+++ b/.github/workflows/nuget-preview.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       sql-server:
-        image: microsoft/mssql-server-linux
+        image: mcr.microsoft.com/mssql/server
         env:
           ACCEPT_EULA: Y
           MSSQL_SA_PASSWORD: Password12!

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       sql-server:
-        image: microsoft/mssql-server-linux
+        image: mcr.microsoft.com/mssql/server
         env:
           ACCEPT_EULA: Y
           MSSQL_SA_PASSWORD: Password12!

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Balea Versions">
-    <Balea>6.0.0$(VersionSuffix)</Balea>
+    <Balea>6.1.0$(VersionSuffix)</Balea>
   </PropertyGroup>
 
   <PropertyGroup Label="Package Dependencies">

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Balea Versions">
-    <Balea>6.1.0$(VersionSuffix)</Balea>
+    <Balea>6.0.1$(VersionSuffix)</Balea>
   </PropertyGroup>
 
   <PropertyGroup Label="Package Dependencies">

--- a/build/docker-compose-cu-sqlserver.yml
+++ b/build/docker-compose-cu-sqlserver.yml
@@ -14,7 +14,7 @@ services:
             - ConnectionStrings__Default=Server=tcp:sqlserver,1433;Initial Catalog=ContosoUniversity;User Id=sa;Password=Password12!
             - ASPNETCORE_ENVIRONMENT=Development
     sqlserver:
-        image: microsoft/mssql-server-linux
+        image: mcr.microsoft.com/mssql/server
         restart: always
         ports:
             - 5433:1433

--- a/build/docker-compose-infrastructure.yml
+++ b/build/docker-compose-infrastructure.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
     sqlserver:
-        image: microsoft/mssql-server-linux
+        image: mcr.microsoft.com/mssql/server
         restart: always
         ports:
             - 5433:1433

--- a/src/Balea/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Balea/DependencyInjection/ServiceCollectionExtensions.cs
@@ -31,15 +31,17 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddAuthorization();
             services.AddHttpContextAccessor();
             services.AddSingleton(sp => sp.GetRequiredService<IOptions<BaleaOptions>>().Value);
+            services.AddSingleton<IAuthorizationPolicyProvider, AuthorizationPolicyProvider>();
+
             services.AddScoped<IPermissionEvaluator, DefaultPermissionEvaluator>();
-            services.AddTransient<IAuthorizationPolicyProvider, AuthorizationPolicyProvider>();
-            services.AddTransient<IAuthorizationHandler, PermissionAuthorizationHandler>();
-            services.AddTransient<IAuthorizationHandler, AbacAuthorizationHandler>();
-            services.AddTransient<IPolicyEvaluator, BaleaPolicyEvaluator>();
             services.AddScoped<IPropertyBag, UserPropertyBag>();
             services.AddScoped<IPropertyBag, ResourcePropertyBag>();
             services.AddScoped<IPropertyBag, ParameterPropertyBag>();
             services.AddScoped<AbacAuthorizationContextFactory>();
+
+            services.AddTransient<IAuthorizationHandler, PermissionAuthorizationHandler>();
+            services.AddTransient<IAuthorizationHandler, AbacAuthorizationHandler>();
+            services.AddTransient<IPolicyEvaluator, BaleaPolicyEvaluator>();
 
             return new BaleaBuilder(services);
         }

--- a/test/FunctionalTests/appsettings.json
+++ b/test/FunctionalTests/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Default": "Server=tcp:localhost,5433;Initial Catalog=Balea;User Id=sa;Password=Password12!;MultipleActiveResultSets=true"
+    "Default": "Server=tcp:localhost,5433;Initial Catalog=Balea;User Id=sa;Password=Password12!;MultipleActiveResultSets=true;Encrypt=false"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
This PR fix the issue with the internal plain dictionary on default policy provider. In some case the access to this dictionary can be concurrent and break the internal state of the dictionary.  For solve this issue we added a lock and serialize access to this dictionary.