### PR TITLE
query improvements

### DIFF
--- a/src/Balea.Api.Store/ApiRuntimeAuthorizationServerStore.cs
+++ b/src/Balea.Api.Store/ApiRuntimeAuthorizationServerStore.cs
@@ -44,20 +44,21 @@ namespace Balea.Api.Store
             if (_storeOptions.CacheEnabled)
             {
                 var key = $"balea:1.0:user:{user.GetSubjectId(_baleaOptions)}:application:{_baleaOptions.ApplicationName}";
-                
+
                 var cachedResponse = await _cache.GetOrSet(
                     key,
-                    miss: () => 
-                    { 
-                        Log.CacheMiss(_logger, key); 
-                        return GetAuthorizationContext(user);
+                    miss: async () =>
+                    {
+                        Log.CacheMiss(_logger, key);
+                        var response = await GetAuthorizationContext(user);
+                        return response.To();
                     },
                     hit: _ => Log.CacheHit(_logger, key),
                     _storeOptions.AbsoluteExpirationRelativeToNow,
                     _storeOptions.SlidingExpiration,
                     cancellationToken);
 
-                return cachedResponse.To();
+                return cachedResponse;
             }
 
             var response = await GetAuthorizationContext(user);
@@ -73,17 +74,18 @@ namespace Balea.Api.Store
 
                 var cachedResponse = await _cache.GetOrSet(
                     key,
-                    miss: () =>
+                    miss: async () =>
                     {
                         Log.CacheMiss(_logger, key);
-                        return GetPolicy(name);
+                        var response = await GetPolicy(name);
+                        return response.To();
                     },
                     hit: _ => Log.CacheHit(_logger, key),
                     _storeOptions.AbsoluteExpirationRelativeToNow,
                     _storeOptions.SlidingExpiration,
                     cancellationToken);
 
-                return cachedResponse.To();
+                return cachedResponse;
             }
 
             var response = await GetPolicy(name);

--- a/src/Balea.Api.Store/ApiRuntimeAuthorizationServerStore.cs
+++ b/src/Balea.Api.Store/ApiRuntimeAuthorizationServerStore.cs
@@ -43,7 +43,7 @@ namespace Balea.Api.Store
         {
             if (_storeOptions.CacheEnabled)
             {
-                var key = $"balea:1.0:user:{user.GetSubjectId(_baleaOptions)}:application:{_baleaOptions.ApplicationName}";
+                var key = $"balea:1.1:user:{user.GetSubjectId(_baleaOptions)}:application:{_baleaOptions.ApplicationName}";
 
                 var cachedResponse = await _cache.GetOrSet(
                     key,
@@ -70,7 +70,7 @@ namespace Balea.Api.Store
         {
             if (_storeOptions.CacheEnabled)
             {
-                var key = $"balea:1.0:application:{_baleaOptions.ApplicationName}:policy:{name}";
+                var key = $"balea:1.1:application:{_baleaOptions.ApplicationName}:policy:{name}";
 
                 var cachedResponse = await _cache.GetOrSet(
                     key,

--- a/src/Balea.Api.Store/Model/HttpClientStoreAuthorizationResponse.cs
+++ b/src/Balea.Api.Store/Model/HttpClientStoreAuthorizationResponse.cs
@@ -20,12 +20,9 @@ namespace Balea.Api.Store.Model
                 Roles.Select(role => new Role(
                     role.Name,
                     role.Description,
-                    role.Subjects,
-                    role.Mappings,
-                    role.Permissions,
-                    role.Enabled)),
-                Delegation is null 
-                    ? null 
+                    role.Permissions)),
+                Delegation is null
+                    ? null
                     : new Delegation(
                         Delegation.Who,
                         Delegation.Whom,

--- a/src/Balea.Configuration.Store/ConfigurationRuntimeAuthorizationServerStore.cs
+++ b/src/Balea.Configuration.Store/ConfigurationRuntimeAuthorizationServerStore.cs
@@ -27,7 +27,7 @@ namespace Balea.Configuration.Store
 
             if (application is null)
             {
-                return Task.FromResult(new AuthorizationContext(new Role[0], null));
+                return Task.FromResult(new AuthorizationContext(Array.Empty<Role>(), null));
             }
 
             var delegation = application.Delegations.GetCurrentDelegation(user.GetSubjectId(_options));

--- a/src/Balea.Configuration.Store/Extensions/ModelExtensions.cs
+++ b/src/Balea.Configuration.Store/Extensions/ModelExtensions.cs
@@ -16,10 +16,7 @@ namespace Balea.Configuration.Store.Model
             return new Role(
                     role.Name,
                     role.Description,
-                    role.Subjects,
-                    role.Mappings,
-                    role.Permissions.Distinct(),
-                    role.Enabled
+                    role.Permissions.Distinct()
                 );
         }
 

--- a/src/Balea.EntityFrameworkCore.Store/EntityFrameworkCoreRuntimeAuthorizationServerStore.cs
+++ b/src/Balea.EntityFrameworkCore.Store/EntityFrameworkCoreRuntimeAuthorizationServerStore.cs
@@ -49,10 +49,7 @@ namespace Balea.EntityFrameworkCore.Store
                 .Select(role => new Role(
                     role.Name,
                     role.Description,
-                    role.Subjects.Select(rs => rs.Subject.Sub),
-                    role.Mappings.Select(rm => rm.Mapping.Name),
-                    role.Permissions.Select(rp => rp.Permission.Name),
-                    role.Enabled
+                    role.Permissions.Select(rp => rp.Permission.Name)
                 ))
                 .ToListAsync(cancellationToken);
 

--- a/src/Balea.EntityFrameworkCore.Store/EntityFrameworkCoreRuntimeAuthorizationServerStore.cs
+++ b/src/Balea.EntityFrameworkCore.Store/EntityFrameworkCoreRuntimeAuthorizationServerStore.cs
@@ -26,44 +26,49 @@ namespace Balea.EntityFrameworkCore.Store
 
         public async Task<AuthorizationContext> FindAuthorizationAsync(ClaimsPrincipal user, CancellationToken cancellationToken = default)
         {
+            var userSubjectId = user.GetSubjectId(_options);
             var sourceRoleClaims = user.GetClaimValues(_options.DefaultClaimTypeMap.RoleClaimType);
-            var delegation = await _context.Delegations.GetCurrentDelegation(
-                user.GetSubjectId(_options),
+
+            var delegation = await _context.Delegations.GetDelegation(
+                userSubjectId,
                 _options.ApplicationName,
                 cancellationToken);
-            var subject = GetSubject(user, delegation);
-            var roles = await _context.Roles
-                    .AsNoTracking()
-                    .Include(r => r.Application)
-                    .Include(r => r.Mappings)
-                    .ThenInclude(rm => rm.Mapping)
-                    .Include(r => r.Subjects)
-                    .ThenInclude(rs => rs.Subject)
-                    .Include(r => r.Permissions)
-                    .ThenInclude(rp => rp.Permission)
-                    .Where(role =>
-                        role.Application.Name == _options.ApplicationName &&
-                        role.Enabled &&
-                        (role.Subjects.Any(rs => rs.Subject.Sub == subject) || role.Mappings.Any(rm => sourceRoleClaims.Contains(rm.Mapping.Name)))
-                    )
-                    .ToListAsync(cancellationToken);
 
-            return new AuthorizationContext(roles.Select(r => r.To()), delegation.To());
+            var subject = delegation?.Who ?? userSubjectId;
+
+            var roles = await _context.Roles
+                .AsNoTracking()
+                .Where(role =>
+                    role.Application.Name == _options.ApplicationName &&
+                    role.Enabled &&
+                    (
+                        role.Subjects.Any(rs => rs.Subject.Sub == subject) ||
+                        role.Mappings.Any(rm => sourceRoleClaims.Contains(rm.Mapping.Name))
+                    )
+                )
+                .Select(role => new Role(
+                    role.Name,
+                    role.Description,
+                    role.Subjects.Select(rs => rs.Subject.Sub),
+                    role.Mappings.Select(rm => rm.Mapping.Name),
+                    role.Permissions.Select(rp => rp.Permission.Name),
+                    role.Enabled
+                ))
+                .ToListAsync(cancellationToken);
+
+            return new AuthorizationContext(roles, delegation);
         }
 
         public async Task<Policy> GetPolicyAsync(string name, CancellationToken cancellationToken = default)
         {
             var policy = await _context
                 .Policies
-                .Include(p => p.Application)
-                .SingleOrDefaultAsync(p => p.Application.Name == _options.ApplicationName && p.Name == name);
+                .AsNoTracking()
+                .Where(p => p.Application.Name == _options.ApplicationName && p.Name == name)
+                .Select(p => new Policy(p.Name, p.Content))
+                .FirstOrDefaultAsync(cancellationToken);
 
-            return policy.To();
-        }
-
-        private string GetSubject(ClaimsPrincipal user, DelegationEntity delegation)
-        {
-            return delegation?.Who?.Sub ?? user.GetSubjectId(_options);
+            return policy;
         }
     }
 }

--- a/src/Balea.EntityFrameworkCore.Store/Extensions/EntitiesExtensions.cs
+++ b/src/Balea.EntityFrameworkCore.Store/Extensions/EntitiesExtensions.cs
@@ -57,8 +57,32 @@ namespace Balea.EntityFrameworkCore.Store.Entities
                         d.Selected &&
                         d.From <= now && d.To >= now &&
                         d.Whom.Sub == subjectId &&
-                        d.Application.Name == applicationName, 
+                        d.Application.Name == applicationName,
                     cancellationToken);
+        }
+
+        public static Task<Delegation> GetDelegation(
+            this DbSet<DelegationEntity> delegations,
+            string subjectId,
+            string applicationName,
+            CancellationToken cancellationToken = default)
+        {
+            var now = DateTime.UtcNow;
+            return delegations
+                .AsNoTracking()
+                .Where(
+                    d =>
+                        d.Selected &&
+                        d.From <= now && d.To >= now &&
+                        d.Whom.Sub == subjectId &&
+                        d.Application.Name == applicationName)
+                .Select(
+                    d => new Delegation(
+                        d.Who.Sub,
+                        d.Whom.Sub,
+                        d.From,
+                        d.To))
+                .FirstOrDefaultAsync(cancellationToken);
         }
 
         public static Policy To(this PolicyEntity policy)

--- a/src/Balea.EntityFrameworkCore.Store/Extensions/EntitiesExtensions.cs
+++ b/src/Balea.EntityFrameworkCore.Store/Extensions/EntitiesExtensions.cs
@@ -19,10 +19,7 @@ namespace Balea.EntityFrameworkCore.Store.Entities
             return new Role(
                         role.Name,
                         role.Description,
-                        role.Subjects.Select(rs => rs.Subject.Sub),
-                        role.Mappings.Select(rm => rm.Mapping.Name),
-                        role.Permissions.Select(rp => rp.Permission.Name),
-                        role.Enabled
+                        role.Permissions.Select(rp => rp.Permission.Name)
                     );
         }
 

--- a/src/Balea/Authorization/BaleaPolicyEvaluator.cs
+++ b/src/Balea/Authorization/BaleaPolicyEvaluator.cs
@@ -150,7 +150,6 @@ namespace Balea.Authorization
             }
 
             var roleClaims = authorization.Roles
-                .Where(role => role.Enabled)
                 .Select(role => new Claim(_options.DefaultClaimTypeMap.RoleClaimType, role.Name));
 
             var permissionClaims = authorization.Roles

--- a/src/Balea/Model/Role.cs
+++ b/src/Balea/Model/Role.cs
@@ -4,39 +4,20 @@ namespace Balea.Model
 {
     public class Role
     {
-        private readonly List<string> _subjects = new List<string>();
-        private readonly List<string> _mappings = new List<string>();
         private readonly List<string> _permissions = new List<string>();
 
         public Role(
             string name,
             string description,
-            IEnumerable<string> subjects,
-            IEnumerable<string> mappings,
-            IEnumerable<string> permissions,
-            bool enabled = true)
+            IEnumerable<string> permissions)
         {
             Name = name;
             Description = description;
-            Enabled = enabled;
-            _subjects.AddRange(subjects);
-            _mappings.AddRange(mappings);
             _permissions.AddRange(permissions);
         }
 
         public string Name { get; private set; }
         public string Description { get; private set; }
-        public bool Enabled { get; private set; }
-
-        public void AddSubjects(IEnumerable<string> subjects)
-        {
-            _subjects.AddRange(subjects);
-        }
-
-        public void AddMappings(IEnumerable<string> mappings)
-        {
-            _mappings.AddRange(mappings);
-        }
 
         public void AddPermissions(IEnumerable<string> permissions)
         {
@@ -46,16 +27,6 @@ namespace Balea.Model
         public IEnumerable<string> GetPermissions()
         {
             return _permissions;
-        }
-
-        public IEnumerable<string> GetMappings()
-        {
-            return _mappings;
-        }
-
-        public IEnumerable<string> GetSubjects()
-        {
-            return _subjects;
         }
     }
 }


### PR DESCRIPTION
The following changes are implemented in this PR: 
- The query that retrieves the roles of a user no longer returns all the subjects a role has been assigned to, as this could pose a security risk by exposing unnecessary information.
- The Mappings property is no longer used outside the query and has been removed.
- The Role Enabled property has been removed, as stores already return only enabled roles and permissions. If this behavior is incorrect, it would indicate a bug in the current code, as enabled roles are added to claims, but permissions from disabled roles are also being added to claims.
- The queries are also changed so that they project the properties that are really needed, optimizing data retrieval and reducing memory footprint.

These changes significantly improve query performance by removing four joins (many-to-many relationships) and avoiding a cartesian explosion, which would otherwise degrade performance based on the number of users a role is assigned to.

**Potential breaking change:** 
This could impact those who have implemented their own store and rely on Balea.Models. However, Balea Server itself remains unaffected, as it returns a custom DTO. Since Balea.Models and the DTO share the same property names, the serializer will omit any additional properties, ensuring compatibility.

Resolves #51 