### PR TITLE
Migrate from Antlr.Runtime to Antlr.Runtime.Standard

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -21,8 +21,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Antlr4.Runtime" Version="4.6.6" />
-    <PackageReference Update="Antlr4.CodeGenerator" Version="4.6.6">
+    <PackageReference Update="Antlr4.Runtime.Standard" Version="4.13.1" />
+    <PackageReference Update="Antlr4BuildTasks" Version="12.10.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -42,8 +42,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Update="Antlr4.Runtime" Version="4.6.6" />
-		<PackageReference Update="Antlr4.CodeGenerator" Version="4.6.6">
+		<PackageReference Update="Antlr4.Runtime.Standard" Version="4.13.1" />
+		<PackageReference Update="Antlr4BuildTasks" Version="12.10.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/Balea/Authorization/Abac/Grammars/BAL/BALVisitor.cs
+++ b/src/Balea/Authorization/Abac/Grammars/BAL/BALVisitor.cs
@@ -1,10 +1,9 @@
 ﻿using Antlr4.Runtime.Misc;
 using Balea.Authorization.Abac.Context;
-using Balea.Authorization.Abac.Grammars.BAL;
 using System;
 using System.Globalization;
 using System.Linq.Expressions;
-using static Balea.Authorization.Abac.Grammars.BAL.BalParser;
+using static BalParser;
 
 namespace Balea.DSL.Grammar.Bal
 {

--- a/src/Balea/Authorization/Abac/Parsers/BALParser.cs
+++ b/src/Balea/Authorization/Abac/Parsers/BALParser.cs
@@ -1,7 +1,6 @@
 ﻿using Antlr4.Runtime;
 using Balea.Authorization.Abac.Context;
 using Balea.Authorization.Abac.Grammars;
-using Balea.Authorization.Abac.Grammars.BAL;
 using Balea.DSL.Grammar.Bal;
 
 namespace Balea.Authorization.Abac.Parsers

--- a/src/Balea/Balea.csproj
+++ b/src/Balea/Balea.csproj
@@ -18,9 +18,12 @@
  
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Antlr4.CodeGenerator" />
-    <PackageReference Include="Antlr4.Runtime" />
+    <PackageReference Include="Antlr4BuildTasks" />
+    <PackageReference Include="Antlr4.Runtime.Standard" />
   </ItemGroup>
-      
 
+   <ItemGroup>
+     <Antlr4 Include="Authorization/Abac/Grammars/BAL/Bal.g4" />
+   </ItemGroup>
+      
 </Project>

--- a/test/FunctionalTests/FunctionalTests.csproj
+++ b/test/FunctionalTests/FunctionalTests.csproj
@@ -49,11 +49,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4.CodeGenerator">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Antlr4.Runtime" />
+    <PackageReference Include="Antlr4BuildTasks" />
+    <PackageReference Include="Antlr4.Runtime.Standard" />
   </ItemGroup>
   <ItemGroup>
     <None Update="balea.json">


### PR DESCRIPTION
The old Antlr.Runtime package has known issues and is no longer maintained. To improve compatibility and ensure future support, it is recommended to migrate to Antlr.Runtime.Standard, which is the actively maintained version.

https://github.com/tunnelvisionlabs/antlr4cs/issues/381